### PR TITLE
Go linting updates

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -108,8 +108,12 @@ func runCmdAdd(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 		if err != nil {
 			zap.S().Errorf("Error arose opening repository collaborators csv file")
 		}
-		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			closeErr := f.Close()
+			if closeErr != nil {
+				zap.S().Warnf("Error closing file: %v", closeErr)
+			}
+		}()
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)
 		collabData, err = csvReader.ReadAll()

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -107,7 +107,12 @@ func runCmdRemove(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 			zap.S().Errorf("Error arose opening repository collaborators csv file")
 		}
 		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			closeErr := f.Close()
+			if closeErr != nil {
+				zap.S().Warnf("Error closing file: %v", closeErr)
+			}
+		}()
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)
 		collabData, err = csvReader.ReadAll()

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -39,7 +39,12 @@ func (g *APIGetter) GetOrgGuestCollaborators(owner string) ([]byte, error) {
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			zap.S().Warnf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -78,7 +83,12 @@ func (g *APIGetter) AddRepoCollaborator(owner string, repo string, username stri
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			zap.S().Warnf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }
 
@@ -108,6 +118,11 @@ func (g *APIGetter) RemoveRepoCollaborator(owner string, repo string, username s
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			zap.S().Warnf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }


### PR DESCRIPTION
### Improvements to error handling:

* **File closure in `cmd/add/add.go` and `cmd/remove/remove.go`:**
  - Updated the `defer` statements to use anonymous functions that log warnings if an error occurs while closing the file. [[1]](diffhunk://#diff-d451b143545dc1c80d2cd3294762db7e07c3112d46a53da6aedccaf407cf9044L111-R116) [[2]](diffhunk://#diff-189480ab096c6d7b6a28710d380aeb21d59e6843726ecf0a8edbee68574a5b5cL110-R115)

* **HTTP response body closure in `internal/utils/general.go`:**
  - Modified the `defer` statements in multiple methods (`GetOrgGuestCollaborators`, `AddRepoCollaborator`, and `RemoveRepoCollaborator`) to log warnings if an error occurs while closing the response body. [[1]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L42-R47) [[2]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L81-R91) [[3]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L111-R126)