### PR TITLE
Removing duplicate flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /gh-collaborators
 /gh-collaborators.exe
 *.csv
+
+.DS_Store

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -89,7 +89,6 @@ func NewCmdAdd() *cobra.Command {
 	addCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	addCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create access from (required)")
 	addCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	addCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	err := addCmd.MarkFlagRequired("from-file")
 	if err != nil {
 		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -87,7 +87,6 @@ func NewCmdRemove() *cobra.Command {
 	removeCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	removeCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to remove access from (required)")
 	removeCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	removeCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	err := removeCmd.MarkFlagRequired("from-file")
 	if err != nil {
 		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)


### PR DESCRIPTION
### Removal of duplicate flag definitions:

* [`cmd/add/add.go`](diffhunk://#diff-d451b143545dc1c80d2cd3294762db7e07c3112d46a53da6aedccaf407cf9044L92): Removed a duplicate declaration of the `debug` flag in the `NewCmdAdd` function.
* [`cmd/remove/remove.go`](diffhunk://#diff-189480ab096c6d7b6a28710d380aeb21d59e6843726ecf0a8edbee68574a5b5cL90): Removed a duplicate declaration of the `debug` flag in the `NewCmdRemove` function.